### PR TITLE
Enable blending before drawing the slot

### DIFF
--- a/src/main/java/chrono/mods/arrows/mixin/GuiMixin.java
+++ b/src/main/java/chrono/mods/arrows/mixin/GuiMixin.java
@@ -111,6 +111,9 @@ public abstract class GuiMixin extends GuiComponent {
 			y -= distance;
 		}
 
+		RenderSystem.defaultBlendFunc();
+		RenderSystem.enableBlend();
+
 		int oldBlitOffset = this.getBlitOffset();
 		this.setBlitOffset(-90);
 		if (arm == HumanoidArm.LEFT) {
@@ -119,9 +122,6 @@ public abstract class GuiMixin extends GuiComponent {
 			this.blit(pose, x, y, 53, 22, 29, 24);
 		}
 		this.setBlitOffset(oldBlitOffset);
-
-		RenderSystem.enableBlend();
-		RenderSystem.defaultBlendFunc();
 
 		if (arm == HumanoidArm.LEFT) {
 			this.renderSlot(x + 3, y + 4, partialTick, player, arrows, 1);


### PR DESCRIPTION
This makes arrows slot background translucent and hides extra pixels on the slot frame to match the look of the off-hand slot.

This is how widget looks at ac92a63
![2023-04-21_09 48 56-](https://user-images.githubusercontent.com/56161020/233531190-c7d70520-f3aa-4bf9-be2f-417e63edc712.png)

And this is how widget looks after c4fb399
![2023-04-21_09 47 50-](https://user-images.githubusercontent.com/56161020/233531202-0fef4951-8d18-4df3-957a-4cbb17a2f9e1.png)

Note that in the second screenshot one can see outline of acacia tree through the slot and there are no extra pixels at the corners of the slot frame.